### PR TITLE
protocol/request-response: Fix memory leak

### DIFF
--- a/src/protocol/request_response/mod.rs
+++ b/src/protocol/request_response/mod.rs
@@ -896,6 +896,8 @@ impl RequestResponseProtocol {
                             "failed to handle substream event",
                         );
                     }
+
+                    self.pending_outbound_cancels.remove(&request_id);
                 }
                 _ = self.pending_outbound_responses.next(), if !self.pending_outbound_responses.is_empty() => {}
                 event = self.pending_inbound_requests.next() => match event {


### PR DESCRIPTION
Cancellation handles did not get removed after the request was handled successfully and would instead stay in the cancellation handle hashmap until the node was shut down.