### PR TITLE
[kademlia] Use `ClosestBucketsIter` from libp2p to get closest peers

### DIFF
--- a/src/protocol/libp2p/kademlia/bucket.rs
+++ b/src/protocol/libp2p/kademlia/bucket.rs
@@ -101,12 +101,10 @@ impl KBucket {
 
     /// Get iterator over the k-bucket, sorting the k-bucket entries in increasing order
     /// by distance.
-    pub fn closest_iter<'a, K: Clone>(
-        &'a mut self,
-        target: Key<K>,
-    ) -> impl Iterator<Item = &'a KademliaPeer> {
-        self.nodes.sort_by(|a, b| target.distance(&a.key).cmp(&target.distance(&b.key)));
-        self.nodes.iter().filter(|peer| !peer.addresses.is_empty())
+    pub fn closest_iter<K: Clone>(&self, target: &Key<K>) -> impl Iterator<Item = KademliaPeer> {
+        let mut nodes = self.nodes.clone();
+        nodes.sort_by(|a, b| target.distance(&a.key).cmp(&target.distance(&b.key)));
+        nodes.into_iter().filter(|peer| !peer.addresses.is_empty())
     }
 }
 
@@ -129,7 +127,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let target = Key::from(PeerId::random());
-        let mut iter = bucket.closest_iter(target.clone());
+        let mut iter = bucket.closest_iter(&target);
         let mut prev = None;
 
         while let Some(node) = iter.next() {
@@ -174,7 +172,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let target = Key::from(PeerId::random());
-        let mut iter = bucket.closest_iter(target.clone());
+        let mut iter = bucket.closest_iter(&target);
         let mut prev = None;
         let mut num_peers = 0usize;
 

--- a/src/protocol/libp2p/kademlia/routing_table.rs
+++ b/src/protocol/libp2p/kademlia/routing_table.rs
@@ -230,23 +230,13 @@ impl ClosestBucketsIter {
     }
 
     fn next_in(&self, i: BucketIndex) -> Option<BucketIndex> {
-        (0..i.get()).rev().find_map(|i| {
-            if self.distance.0.bit(i) {
-                Some(BucketIndex(i))
-            } else {
-                None
-            }
-        })
+        (0..i.get())
+            .rev()
+            .find_map(|i| self.distance.0.bit(i).then_some(BucketIndex(i)))
     }
 
     fn next_out(&self, i: BucketIndex) -> Option<BucketIndex> {
-        (i.get() + 1..NUM_BUCKETS).find_map(|i| {
-            if !self.distance.0.bit(i) {
-                Some(BucketIndex(i))
-            } else {
-                None
-            }
-        })
+        (i.get() + 1..NUM_BUCKETS).find_map(|i| (!self.distance.0.bit(i)).then_some(BucketIndex(i)))
     }
 }
 


### PR DESCRIPTION
Find peers in the routing table close to target using `ClosestBucketsIter` from libp2p.

Resolves https://github.com/altonen/litep2p/issues/38.